### PR TITLE
changed line height for small text

### DIFF
--- a/covid-19/style.css
+++ b/covid-19/style.css
@@ -47,7 +47,7 @@
 
 .rt__description--small {
   font-size: 12px;
-  line-height: 1;
+  line-height: 1.6;
   color: #ccc;
 }
 


### PR DESCRIPTION
Привет! Предлагаю пофиксить высоту строк для блока с ссылкой.

![image](https://user-images.githubusercontent.com/1647208/83539364-fa3edf80-a507-11ea-96e0-a0aeff226426.png)

На мой взгляд, так текст читается лучше.